### PR TITLE
Add active classes in navbar via ui-sref-active

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -26,9 +26,10 @@
     <header class="header">
       <h3 class="text-muted">MOS Energy Benchmark</h3>
       <ul class="nav nav-pills pull-right">
-        <li class="active"><a ui-sref="charts">Charts</a></li>
-        <li><a ui-sref="map">Map</a></li>
-        <li><a ui-sref="info">Info</a></li>
+        <li ui-sref-active="active"><a ui-sref="charts">Charts</a></li>
+        <!-- TODO: Figure out how to show map highlight when detail/compare is active? -->
+        <li ui-sref-active="active"><a ui-sref="map">Map</a></li>
+        <li ui-sref-active="active"><a ui-sref="info">Info</a></li>
       </ul>
     </header>
     <div ui-view class="content">


### PR DESCRIPTION
I couldn't come up with a trivial way to display the highlight under map when the view is detail or compare. Saving that for later since this gets most of it right (and I'm not even sure adding the highlight for those two views makes sense)
