### PR TITLE
Closes #85: Add lazyLoad attribute to each mos chart

### DIFF
--- a/app/scripts/charting/barchart-directive.js
+++ b/app/scripts/charting/barchart-directive.js
@@ -7,6 +7,7 @@
         plotHeight: 200,
         yDefault: 'avgemissions',
         transitionMillis: 500,
+        lazyLoad: true,
         binType: 'temporal'
     };
 
@@ -31,6 +32,7 @@
             plotHeight: '@',
             margin: '&',
             binType: '@',
+            lazyLoad: '@',
             transitionMillis: '@'
         };
 

--- a/app/scripts/charting/bubblechart-directive.js
+++ b/app/scripts/charting/bubblechart-directive.js
@@ -6,6 +6,7 @@
         plotWidth: 500,
         plotHeight:500,
         bubblePadding: 25,
+        lazyLoad: true,
         transitionTime: 500
     };
 
@@ -35,6 +36,7 @@
             plotWidth: '@',
             plotHeight: '@',
             bubblePadding: '@',
+            lazyLoad: '@',
             transitionTime: '@'
         };
 

--- a/app/scripts/charting/charting-controller.js
+++ b/app/scripts/charting/charting-controller.js
@@ -40,7 +40,7 @@
 
         // Wrapper for the plot function, called from $scope.$watch
         $scope.redraw = function (data) {
-            if (!data || $scope.plotComplete || !Utils.inViewPort($element)) {
+            if (!data || $scope.plotComplete || ($scope.config.lazyLoad && !Utils.inViewPort($element))) {
                 return;
             }
             $scope.plot(data);

--- a/app/scripts/charting/histogram-directive.js
+++ b/app/scripts/charting/histogram-directive.js
@@ -9,6 +9,7 @@
         barRadius: 4,
         valueField: '',
         transitionMillis: 500,
+        lazyLoad: false,
         bgFillColor: '#F0F1F2'
     };
 
@@ -39,7 +40,8 @@
             calloutValues: '=',
             calloutColors: '=',
             transitionMillis: '@',
-            allowRedraw: '@'
+            allowRedraw: '@',
+            lazyLoad: '@'
         };
 
 

--- a/app/scripts/charting/scatterplot-directive.js
+++ b/app/scripts/charting/scatterplot-directive.js
@@ -12,7 +12,8 @@
         areaDefaultDim: 'electricity',
         colorDefaultDim: 'sector',
         minRadius: 1,
-        maxRadius: 6
+        maxRadius: 6,
+        lazyLoad: true
     };
 
     /**
@@ -49,6 +50,7 @@
             colorDefaultDim: '@',
             minRadius: '@',
             maxRadius: '@',
+            lazyLoad: '@',
             margin: '&'
         };
 

--- a/app/scripts/charting/time-scatterplot-directive.js
+++ b/app/scripts/charting/time-scatterplot-directive.js
@@ -13,6 +13,7 @@
         currColor: '#CC3366',
         prevRadius: 6,
         currRadius: 6,
+        lazyLoad: true,
         transitionMillis: 500
     };
 
@@ -48,6 +49,7 @@
             currColor: '@',
             prevRadius: '@',
             currRadius: '@',
+            lazyLoad: '@',
             transitionMillis: '@'
         };
 


### PR DESCRIPTION
lazyLoad delays chart drawing until the chart is visible
in the browser viewport.

mos-histogram defaults to false, all others default to true,
matching the behaviour of the charts on the page. Customize by
passing a lazy-load attribute on the chart html element.
