### PR TITLE
Fixes #134: Use units on compare/detail pages

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -32,6 +32,9 @@
 
     // min. values and corresponding CSS values for each bucket
     var CssValues = {
+            'energy_star': {
+                description: 'Energy Star'
+            },
             'floor_area': {
                 'cssVal': 'marker-fill',
                 'description': 'Square Footage',

--- a/app/scripts/views/compare/compare-controller.js
+++ b/app/scripts/views/compare/compare-controller.js
@@ -2,26 +2,26 @@
     'use strict';
 
     var CompareConfig = {
-        fields: {
-            'energy_star': 'Energy Star Score',
-            'site_eui': 'EUI',
-            'total_ghg': 'Emissions',
-            'electricity': 'Electric Usage',
-            'natural_gas': 'Natural Gas Usage',
-            'fuel_oil': 'Oil Usage',
-            'steam': 'Steam Usage',
-            'water_use': 'Water Usage'
-        }
+        fields: [
+            'energy_star',
+            'site_eui',
+            'total_ghg',
+            'electricity',
+            'natural_gas',
+            'fuel_oil',
+            'steam',
+            'water_use'
+        ]
     };
 
     /*
      * ngInject
      */
-    function CompareController($scope, BuildingCompare, CompareConfig, buildingData, currentData) {
+    function CompareController($scope, BuildingCompare, CompareConfig, MOSCSSValues, buildingData, currentData) {
 
         var setCalloutValues = function (data, fields) {
             var calloutValues = {};
-            angular.forEach(fields, function (readable, key) {
+            angular.forEach(fields, function (key) {
                 calloutValues[key] = [];
                 for (var i = 0; i < data.length; i++) {
                     calloutValues[key].push(data[i][key]);
@@ -34,6 +34,7 @@
         $scope.buildings = buildingData.data.rows;
         $scope.fields = CompareConfig.fields;
         $scope.currentData = currentData.data.rows;
+        $scope.cssValues = MOSCSSValues;
         $scope.calloutColors = [
             '#8FBD84',
             '#81ABCC',

--- a/app/scripts/views/compare/compare-partial.html
+++ b/app/scripts/views/compare/compare-partial.html
@@ -26,12 +26,12 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="(key, readable) in fields">
-                    <td class="category">{{ ::readable }}</td>
+                <tr ng-repeat="key in fields">
+                    <td class="category" ng-bind-html="cssValues[key].description"></td>
                     <!-- Tried ng-class="bld-{{$index+1}}", didn't seem to work? -->
                     <td class="compare"
                         ng-class="{'bld-1': $index === 0, 'bld-2': $index === 1, 'bld-3': $index === 2}"
-                        ng-repeat="building in buildings">{{ ::building[key] | cartodbNumber }}</td>
+                        ng-repeat="building in buildings">{{ ::building[key] | cartodbNumber:0 }}</td>
                     <td>
                         <mos-histogram plot-height="80"
                                        plot-width="300"

--- a/app/scripts/views/detail/detail-controller.js
+++ b/app/scripts/views/detail/detail-controller.js
@@ -5,15 +5,15 @@
      * ngInject
      */
     var DetailConfig = {
-        fields: {
-            'site_eui': 'EUI',
-            'total_ghg': 'Emissions',
-            'electricity': 'Electric Usage',
-            'natural_gas': 'Natural Gas Usage',
-            'fuel_oil': 'Oil Usage',
-            'steam': 'Steam Usage',
-            'water_use': 'Water Usage'
-        },
+        fields: [
+            'site_eui',
+            'total_ghg',
+            'electricity',
+            'natural_gas',
+            'fuel_oil',
+            'steam',
+            'water_use'
+        ],
         FILTER: {
             NONE: 'none',
             SECTOR: 'sector'
@@ -23,7 +23,7 @@
     /*
      * ngInject
      */
-    function DetailController($scope, DetailConfig, MOSColors, buildingData, currentData) {
+    function DetailController($scope, DetailConfig, MOSColors, MOSCSSValues, buildingData, currentData) {
 
 /* jshint laxbreak:true */
         var building = buildingData.data && buildingData.data.rows && buildingData.data.rows.length > 0
@@ -35,6 +35,7 @@
         $scope.building = building;
         $scope.fields = DetailConfig.fields;
         $scope.currentData = rows;
+        $scope.cssValues = MOSCSSValues;
         $scope.filterField = 'sector';
         $scope.calloutColors = [sectorColor];
         $scope.FILTER = DetailConfig.FILTER;

--- a/app/scripts/views/detail/detail-partial.html
+++ b/app/scripts/views/detail/detail-partial.html
@@ -10,7 +10,7 @@
             </div>
             <div class="col-xs-4 pull-right">
                 <div class="energy-star center-block text-center">
-                    <h4>{{ ::building.energy_star | cartodbNumber }}</h4>
+                    <h4>{{ ::building.energy_star | cartodbNumber:0 }}</h4>
                     <label>Energy Star Score</label>
                 </div>
             </div>
@@ -45,12 +45,12 @@
         </div>
     </div>
 
-    <div ng-repeat="(key, readable) in fields"class="row stats" ng-if="building[key]">
+    <div ng-repeat="key in fields"class="row stats" ng-if="building[key]">
         <div class="col-xs-3">
-            <p>{{ ::readable }}</p>
+            <p ng-bind-html="cssValues[key].description"></p>
         </div>
         <div class="col-xs-3">
-            <h3 class="pull-right"><strong>{{ building[key] | cartodbNumber:1 }}</strong></h3>
+            <h3 class="pull-right"><strong>{{ ::building[key] | cartodbNumber:0 }}</strong></h3>
         </div>
         <div class="col-xs-6">
             <mos-histogram plot-height="100"


### PR DESCRIPTION
Sets numbers to display as integers
Adds Energy Star to MOSCSSValues
DRY: display descriptions using MOSCSSValues
Use one-time binding for detail values
