### PR TITLE
Remove single quotes from page values

### DIFF
--- a/app/scripts/views/charts/charts-partial.html
+++ b/app/scripts/views/charts/charts-partial.html
@@ -105,5 +105,5 @@
         </div>
         <div class="next"><a type="button" class="btn btn-md btn-next" mos-panel-snap-next><i class="fa fa-angle-up"></i></a></div>
     </section>
-    <mos-charts-glossary page="'charts'"></mos-charts-glossary>
+    <mos-charts-glossary page="charts"></mos-charts-glossary>
 </div>

--- a/app/scripts/views/compare/compare-partial.html
+++ b/app/scripts/views/compare/compare-partial.html
@@ -46,6 +46,5 @@
             </tbody>
         </table>
     </div>
-    <mos-charts-glossary page="'compare'"></mos-charts-glossary>
+    <mos-charts-glossary page="compare"></mos-charts-glossary>
 </div>
-

--- a/app/scripts/views/detail/detail-partial.html
+++ b/app/scripts/views/detail/detail-partial.html
@@ -63,5 +63,5 @@
             </mos-histogram>
         </div>
     </div>
-    <mos-charts-glossary page="'detail'"></mos-charts-glossary>
+    <mos-charts-glossary page="detail"></mos-charts-glossary>
 </div>


### PR DESCRIPTION
This was causing the single quotes to show up in the string, and the check for not displaying it on the charts page wasn't working.
