### PR TITLE
Consolidate conflicting map styling

### DIFF
--- a/app/scripts/views/map/map-controller.js
+++ b/app/scripts/views/map/map-controller.js
@@ -229,7 +229,7 @@
           '<p><label><input type="checkbox" ng-model="compare.isChecked" ng-disabled="compare.disabled" ',
           'ng-change="setCompare(propertyData.cartodbId)" /> <em>Compare</em></label>',
           '<button type="button" class="pull-right btn btn-popover" ',
-          'ng-style="{\'background-color\': \'{{::propertyData.sectorColor}}\',  \'opacity\': 0.6 }" ',
+          'ng-style="{\'background-color\': \'{{::propertyData.sectorColor}}\',  \'opacity\': 0.8 }" ',
           'ui-sref="detail({buildingId: propertyData.cartodbId})">Full Report</button></p>',
           '</div></div></span>'].join('');
 

--- a/app/styles/_map.scss
+++ b/app/styles/_map.scss
@@ -27,19 +27,14 @@ div.leaflet-popup-content-wrapper {
   overflow: hidden;
 }
 
-a.leaflet-popup-close-button {
-  text-shadow: 1px 1px 1px #000;
+.leaflet-container a.leaflet-popup-close-button {
+  color: #ddd!important;
+  padding: 6px 6px 0 0!important;
   z-index: 999;
 }
 
-span.featurePopup p {
-  margin-left: 7px;
-  margin-right: 7px;
-}
-
-span.featurePopup h4 {
-  margin-left: 7px;
-  margin-right: 7px;
+.popupContent{
+  padding: 18px;
 }
 
 span.featurePopup button {
@@ -49,14 +44,38 @@ span.featurePopup button {
   background-color: #706f6c;
 }
 
-div.headerPopup {
-  padding-top: 27px;
-  padding-bottom: 2px;
-  color: white;
-  opacity: 0.7;
-  text-shadow: 1px 1px 1px #000;
+.featurePopup p {
+  margin-left: 8px 0!important;
+  margin-right: 8px 0!important;
+  font-size: 0.7rem;
+
+  strong{
+    float: right;
+    font-family: 'Roboto Slab', serif;
+    font-weight: 700;
+    font-size: 1rem;
+    color: $heading;
+  }
 }
 
+.featurePopup .headerPopup p {
+    margin: 2px 0 !important;
+}
+
+.headerPopup {
+  padding-top: 27px;
+  padding-bottom: 2px;
+  padding-left: 18px;
+  padding-right: 18px;
+  color: $paper;
+  opacity: 0.8;
+  text-shadow: 1px 1px 1px #000;
+
+  h4{
+    margin: 8px 0 0 0!important;
+    padding-bottom: 10px;
+  }
+}
 
 /* search icon within input field */
 div.search-group {

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -719,44 +719,8 @@ html, body, .content, .chart-hero, .chart-footer {
   }
 }
 
-.headerPopup{
-  padding: 18px;
-  color: $paper;
-  text-shadow: 0 0 2px rgba(0,0,0,.3)!important;
 
-  h4{
-    margin: 8px 0 0 0!important;
-    padding-bottom: 10px;
-  }
-}
-
-.popupContent{
-  padding: 18px;
-}
-
-.featurePopup p{
-  margin: 8px 0!important;
-  font-size: 0.7rem;
-
-  strong{
-    float: right;
-    font-family: 'Roboto Slab', serif;
-    font-weight: 700;
-    font-size: 1rem;
-    color: $heading;
-  }
-}
-
-.featurePopup .headerPopup p {
-    margin: 2px 0 !important;
-}
-
-.leaflet-container a.leaflet-popup-close-button{
-  color: $paper!important;
-  text-shadow: none!important;
-  padding: 6px 6px 0 0!important;
-}
-
+/* Legends appear both on charts page and map */
 .cartodb-legend, .cartodb-legend-stack{
   box-shadow: 0 0 4px $filter-border!important;
   border-color: $filter-border!important;


### PR DESCRIPTION
Combine a number of conflicting/duplicated styling rules between main.scss and _map.scss.

@ctaylo37 will need to take a look; when looking at the pop-ups, please also check that the address search pop-ups look okay (they don't have the styled header sections on them).
