### PR TITLE
Fix popup styling for IE

### DIFF
--- a/app/scripts/views/charts/charts-controller.js
+++ b/app/scripts/views/charts/charts-controller.js
@@ -6,7 +6,7 @@
     /*
      * ngInject
      */
-    function ChartsController($scope, $cookieStore, $q, CartoSQLAPI, ChartingUtils) {
+    function ChartsController($scope, $cookieStore, $q, CartoSQLAPI) {
         // Initialize
         $scope.loadingView = true;
         var previousData = [];

--- a/app/styles/_map.scss
+++ b/app/styles/_map.scss
@@ -42,6 +42,11 @@ div.leaflet-popup-content-wrapper {
   padding: 18px;
 }
 
+.geocodePopup {
+  background-color: #666666;
+  height: 50px;
+}
+
 span.featurePopup button {
   margin-left: 7px;
   margin-right: 7px;


### PR DESCRIPTION
Adding a class instead of messing with `ng-style`; see #179
