### PR TITLE
Closes #197: Use mos-benchmarking account for all SQL api calls

### DIFF
--- a/app/scripts/cartodb/cartodb-api-config.js
+++ b/app/scripts/cartodb/cartodb-api-config.js
@@ -7,6 +7,9 @@
     function CartoConfig (Utils) {
         var module = {};
 
+        module.user = 'mos-benchmarking';
+        module.visualization = '5e5cbbf0-8ac3-11e4-bf05-0e9d821ea90d';
+
         // The unique column to use to identify records throughout the app
         module.uniqueColumn = 'cartodb_id';
 
@@ -30,7 +33,7 @@
         // it easier to swap in newer sets of data. There are
         // no current plans to support more than two years of data.
         module.data = {
-            url: 'http://azavea-demo.cartodb.com/api/v2/sql',
+            url: 'http://' + module.user + '.cartodb.com/api/v2/sql',
 
 /* jshint laxbreak:true */
             prevQuery: 'SELECT'

--- a/app/scripts/mapping/mapping-service.js
+++ b/app/scripts/mapping/mapping-service.js
@@ -26,7 +26,7 @@
          */
         module.getBldgCategories = function() {
             var qry = 'SELECT DISTINCT sector FROM {{tbl}} order by sector;';
-            var sql = new cartodb.SQL({ user: 'azavea-demo'});
+            var sql = new cartodb.SQL({ user: CartoConfig.user });
             return sql.execute(qry, {tbl: table});
         };
 
@@ -39,7 +39,7 @@
         module.featureLookup = function(cartodbId)  {
             var qry = 'SELECT cartodb_id, phl_bldg_id, property_name, address, floor_area, total_ghg, site_eui, ' +
             'energy_star, sector FROM {{tbl}} where cartodb_id = {{id}}';
-            var sql = new cartodb.SQL({ user: 'azavea-demo'});
+            var sql = new cartodb.SQL({ user: CartoConfig.user });
             return sql.execute(qry, { id: cartodbId, tbl: table });
         };
 
@@ -53,7 +53,7 @@
         module.featureLookupByBldgId = function(bldgId)  {
             var qry = 'SELECT cartodb_id, property_name, address, total_ghg, site_eui, ' +
             'energy_star, sector, x, y FROM {{tbl}} where phl_bldg_id = \'{{bldgId}}\';';
-            var sql = new cartodb.SQL({ user: 'azavea-demo'});
+            var sql = new cartodb.SQL({ user: CartoConfig.user });
             return sql.execute(qry, { bldgId: bldgId, tbl: table});
         };
 
@@ -64,7 +64,7 @@
          */
         module.getBuildingIds = function() {
             var qry = 'SELECT DISTINCT phl_bldg_id FROM {{tbl}};';
-            var sql = new cartodb.SQL({ user: 'azavea-demo'});
+            var sql = new cartodb.SQL({ user: CartoConfig.user });
             return sql.execute(qry, {tbl: table});
         };
 

--- a/app/scripts/views/map/map-controller.js
+++ b/app/scripts/views/map/map-controller.js
@@ -4,7 +4,7 @@
     /*
      * ngInject
      */
-    function MapController($compile, $q, $scope, $state, $timeout, BuildingCompare, MappingService, ColorService) {
+    function MapController($compile, $q, $scope, $state, $timeout, BuildingCompare, CartoConfig, MappingService, ColorService) {
 
         // indicate that map is loading, hang on..
         $scope.mapLoading = true;
@@ -276,7 +276,7 @@
         });
 
         // load map visualization
-        cartodb.createVis('mymap', 'http://mos-benchmarking.cartodb.com/api/v2/viz/5e5cbbf0-8ac3-11e4-bf05-0e9d821ea90d/viz.json',
+        cartodb.createVis('mymap', 'http://' + CartoConfig.user + '.cartodb.com/api/v2/viz/' + CartoConfig.visualization + '/viz.json',
                           {'infowindow': false, 'legends': false, 'searchControl': false, 'loaderControl': true})
             .done(function(vis, layers) {
                 $scope.mapLoading = false;

--- a/app/scripts/views/map/module.js
+++ b/app/scripts/views/map/module.js
@@ -23,6 +23,7 @@
         'ngSanitize',
         'ui.router',
         'ui.bootstrap',
+        'mos.cartodb',
         'mos.compare',
         'mos.colors',
         'mos.mapping'


### PR DESCRIPTION
Sets config options in CartoConfig service that are used globally.
Before, we had the account name scattered all over the code, yuck.