### PR TITLE
Add 2015

### DIFF
--- a/app/scripts/cartodb/cartodb-api-config.js
+++ b/app/scripts/cartodb/cartodb-api-config.js
@@ -9,7 +9,7 @@
         var year = YearService.getCurrentYear();
 
         module.user = 'mos-benchmarking';
-        module.visualization = 'aed2ea1e-5bd3-11e5-b15b-0e853d047bba';
+        module.visualization = '3b378ea5-1631-4dee-b0d0-a271c107aefc';
 
         // The unique column to use to identify records throughout the app
         module.uniqueColumn = 'cartodb_id';
@@ -27,6 +27,11 @@
                 avgEnergyStar: 59,
                 ghgBuildings: 60,
                 numBuildings: 1879
+            },
+            2015: {
+                avgEnergyStar: 0,
+                ghgBuildings: 0,
+                numBuildings: 0
             }
         };
 

--- a/app/scripts/views/info/info-partial.html
+++ b/app/scripts/views/info/info-partial.html
@@ -12,7 +12,7 @@
     <div class="row">
         <div class="col-md-offset-2 col-md-8">
             <h4>About this tool</h4>
-            <p>This visualization tool provides building-level energy performance data for the 2013 and 2014 calendar years for the nearly 2,000 properties required to report utility information as part of Philadelphia’s energy benchmarking law. You can learn more about energy benchmarking and read the Year Two Benchmarking Report at <a href="http://www.phila.gov/benchmarking" target="_blank">www.phila.gov/benchmarking</a>.</p>
+            <p>This visualization tool provides building-level energy performance data for the 2013, 2014, and 2015 calendar years for the nearly 2,000 properties required to report utility information as part of Philadelphia’s energy benchmarking law. You can learn more about energy benchmarking and read the Year Two Benchmarking Report at <a href="http://www.phila.gov/benchmarking" target="_blank">www.phila.gov/benchmarking</a>.</p>
             <br>
 
             <h4>Building Energy Performance</h4>

--- a/app/scripts/years/year-service.js
+++ b/app/scripts/years/year-service.js
@@ -8,7 +8,7 @@
         var module = {};
 
         // Available years -- must match up to visualization subLayer order
-        module.years = [2014, 2013];
+        module.years = [2015, 2014, 2013];
         module.getCurrentYear = getCurrentYear;
 
         return module;


### PR DESCRIPTION
Switch to visualization with data for 2013-2015.

Use visualization created for #215 and add third year with 2015 data.

Needs styling work to make third column of data fit on detail page and in map popup.

Also needs summary figures for the configuration file; in calculating the summary numbers for previous years, there was a mismatch, so the calculations and sources for those numbers will need to be confirmed.

Purpose of this PR is to get 2015 data in so styling work may proceed for #218.
