### PR TITLE
Add global bower install to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dependencies:
 # TODO: Add vagrant vm
 sudo apt-get install ruby1.9.1-dev
 sudo gem install sass compass
-sudo npm install -g grunt-cli
+sudo npm install -g grunt-cli bower
 npm install
 bower install
 ```


### PR DESCRIPTION
## Overview

I followed the instructions, which failed because I didn't have the bower CLI tool installed.

Feel free to merge once approved if this looks ok.