### PR TITLE
Update geocoder for new endpoint

### DIFF
--- a/app/scripts/mapping/mapping-service.js
+++ b/app/scripts/mapping/mapping-service.js
@@ -109,20 +109,20 @@
         module.geocode = function(address) {
 
             var dfd = $q.defer();
-            var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find';
+            var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates';
             // limit search to greater Philadelphia region
 
             $http.get(url, {
                 params: {
-                    'text': address,
-                    'bbox': viewbox,
+                    'singleLine': address,
+                    'searchExtent': viewbox,
                     'category': 'Address,Postal',
                     'outFields': 'StAddr,City,Postal',
                     'maxLocations': 1,
                     'f': 'pjson'
                 }
             }).then(function (data) {
-                dfd.resolve(data.data.locations);
+                dfd.resolve(data.data.candidates);
             }, function () {
                 dfd.resolve([]);
             });

--- a/app/scripts/views/map/map-controller.js
+++ b/app/scripts/views/map/map-controller.js
@@ -160,8 +160,8 @@
                     var result = data[0];
 
                     // show popup with found addresss display name
-                    var geometry = result.feature.geometry;
-                    var latlng = L.latLng(geometry.y, geometry.x);
+                    var location = result.location;
+                    var latlng = L.latLng(location.y, location.x);
 
                     nativeMap.setView(latlng, 16);
                     $scope.noResults = false;
@@ -171,7 +171,7 @@
                         '<span class="featurePopup"><div class="headerPopup geocodePopup"></div>',
                         '<div class="popupContent"><p>{{::geocodedDisplayName}}</p></div></span>'
                     ].join('');
-                    var attrs = result.feature.attributes;
+                    var attrs = result.attributes;
                     /* jshint camelcase:false */
                     $scope.geocodedDisplayName = [
                         attrs.StAddr,


### PR DESCRIPTION
### Overview

ESRI geocoder `find` endpoint deprecated; switch to new [findAddressCandidates](https://developers.arcgis.com/rest/geocode/api-reference/geocoding-find-address-candidates.htm) endpoint.

### Testing:

 * `grunt serve`
 * Search for an address on the map page. Note it is necessary to hit 'enter' to go to selected result (this was the previous behavior)
 * Map view should zoom to selected address and display a popup with the address.

Closes #226 
