### PR TITLE
Feature/kak/create staging site#233

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: node_js
 node_js:
-  - '6'
+  - '8'
 addons:
   chrome: stable
 before install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,12 @@ before_script:
   - npm install -g bower grunt-cli
   - npm install
   - bower install
+before_deploy:
+    grunt build
+deploy:
+  provider: pages
+  local_dir: dist
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  on:
+    branch: develop


### PR DESCRIPTION
Publish `develop` branch to GitHub Pages for this repository automatically as part of Travis build.

## Testing

[This build](https://travis-ci.org/flibbertigibbet/mos-energy-benchmark/builds/270408806) on my fork had the deploy branch set to this feature branch, and so published to the [GitHub Pages for my fork](http://flibbertigibbet.github.io/mos-energy-benchmark/). Check that the site there functions as expected.

Closes #233.
