### PR TITLE
Feature/kak/parameterize info page#245

### DIFF
--- a/app/scripts/cartodb/cartodb-api-config.js
+++ b/app/scripts/cartodb/cartodb-api-config.js
@@ -14,6 +14,7 @@
         module.uniqueColumn = 'cartodb_id';
 
         module.yearsTable = 'mos_years';
+        module.infoTable = 'mos_info';
 
         // Fields which do not use a year suffix
         module.timeIndependentFields = ['year_built', 'floor_area'];
@@ -64,6 +65,10 @@
 
             yearsQuery: Utils.strFormat('SELECT * from {table} ORDER BY year DESC', {
                 table: module.yearsTable
+            }),
+
+            infoQuery: Utils.strFormat('SELECT * from {table}', {
+                table: module.infoTable
             })
 
 /* jshint laxbreak:false */

--- a/app/scripts/cartodb/cartodb-api-service.js
+++ b/app/scripts/cartodb/cartodb-api-service.js
@@ -43,6 +43,17 @@
             return currentData;
         };
 
+        /*
+         *  Converts info page table data to object with key-value pairs
+         */
+        module.getInfo = function(infoData) {
+            var info = {};
+            angular.forEach(infoData, function(row) {
+                info[row.key] = row.value;
+            });
+            return info;
+        };
+
         module.getAllCurrentData = function() {
             return makeCartoDBRequest(CartoConfig.data.currAllQuery, {
                 year: getCurrentYear(),
@@ -76,6 +87,14 @@
                 id: ids,
                 table: getTableName()
             });
+        };
+
+        /**
+         * Get the table of parameterized data for the info page
+         * @return {$httpPromise}
+         */
+        module.getInfoData = function() {
+            return makeCartoDBRequest(CartoConfig.data.infoQuery);
         };
 
         /**

--- a/app/scripts/views/info/info-controller.js
+++ b/app/scripts/views/info/info-controller.js
@@ -6,10 +6,16 @@
      */
     function InfoController($scope, CartoSQLAPI, infoData) {
 
-        console.log(infoData);
+        $scope.info = infoData;
 
         $scope.yearsString = '';
         setYearsString(CartoSQLAPI.years);
+
+        // Strip the scheme from a url, for presentation as link text
+        $scope.getPrettyUrl = function(url) {
+           var [, two] = _.split(url, '//');
+           return two || url;
+        };
 
         // Update years values and download links after they have been loaded from Carto
         $scope.$on('mos.cartodb:years', function(event, data) {

--- a/app/scripts/views/info/info-controller.js
+++ b/app/scripts/views/info/info-controller.js
@@ -4,7 +4,9 @@
     /*
      * ngInject
      */
-    function InfoController($scope, CartoSQLAPI) {
+    function InfoController($scope, CartoSQLAPI, infoData) {
+
+        console.log(infoData);
 
         $scope.yearsString = '';
         setYearsString(CartoSQLAPI.years);

--- a/app/scripts/views/info/info-partial.html
+++ b/app/scripts/views/info/info-partial.html
@@ -12,15 +12,15 @@
     <div class="row">
         <div class="col-md-offset-2 col-md-8">
             <h4>About this tool</h4>
-            <p>This visualization tool provides building-level energy performance data for the {{ ::yearsString }} calendar years for the nearly 2,000 properties required to report utility information as part of Philadelphia’s energy benchmarking law. You can learn more about energy benchmarking and read the benchmarking reports at <a href="{{ ::info.benchmarking_url }}" target="_blank">{{ ::getPrettyUrl(info.benchmarking_url) }}</a>.</p>
+            <p>This visualization tool provides building-level energy performance data for the {{ ::yearsString }} calendar years for the {{ ::info.reporting_properties }} properties required to report utility information as part of Philadelphia’s energy benchmarking law. You can learn more about energy benchmarking and read the benchmarking reports at <a href="{{ ::info.benchmarking_url }}" target="_blank">{{ ::getPrettyUrl(info.benchmarking_url) }}</a>.</p>
             <br>
 
             <h4>Building Energy Performance</h4>
-            <p>Building energy performance is a critical metric for cities dedicated to reducing greenhouse gas emissions. In Philadelphia, more than 60 percent of citywide greenhouse gas emissions stem from building energy use. As part of the City’s <a href="#" target="_blank">Greenworks sustainability plan</a>, Philadelphia set a goal to reduce emissions 20 percent by 2015. Improving building performance will help Philadelphia reach that goal, and benchmarking provides building owners with the information they need to begin making informed decisions about upgrading and investing in energy efficiency (see <a href="#" target="_blank">this page</a> for existing resources to invest in your facility).</p>
+            <p>Building energy performance is a critical metric for cities dedicated to reducing greenhouse gas emissions. In Philadelphia, {{ ::info.greenhouse_emissions }} of citywide greenhouse gas emissions stem from building energy use. As part of the City’s <a href="{{ ::info.greenworks_plan_url }}" target="_blank">Greenworks sustainability plan</a>, Philadelphia set a goal to {{ ::info.sustainability_plan_goal }}. Improving building performance will help Philadelphia reach that goal, and benchmarking provides building owners with the information they need to begin making informed decisions about upgrading and investing in energy efficiency (see <a href="{{ ::info.investing_in_efficiency_url }}" target="_blank">this page</a> for existing resources to invest in your facility).</p>
             <br>
 
             <h4>Credits</h4>
-            <p>This tool was developed for the Mayor’s Office of Sustainability (MOS) by <a href="http://www.azavea.com/" target="_blank">Azavea Inc.</a>  Questions about the tool, the data, or the energy benchmarking program can be directed to MOS at <a href="mailto:benchmarkinghelp@phila.gov">benchmarkinghelp@phila.gov</a>.</p>
+            <p>This tool was developed for the Mayor’s Office of Sustainability (MOS) by <a href="http://www.azavea.com/" target="_blank">Azavea Inc.</a>  Questions about the tool, the data, or the energy benchmarking program can be directed to MOS at <a href="mailto:{{ ::info.contact_email }}">{{ ::info.contact_email }}</a>.</p>
         </div>
     </div>
 </div>

--- a/app/scripts/views/info/info-partial.html
+++ b/app/scripts/views/info/info-partial.html
@@ -12,7 +12,7 @@
     <div class="row">
         <div class="col-md-offset-2 col-md-8">
             <h4>About this tool</h4>
-            <p>This visualization tool provides building-level energy performance data for the {{ ::yearsString }} calendar years for the nearly 2,000 properties required to report utility information as part of Philadelphia’s energy benchmarking law. You can learn more about energy benchmarking and read the Year Two Benchmarking Report at <a href="http://www.phila.gov/benchmarking" target="_blank">www.phila.gov/benchmarking</a>.</p>
+            <p>This visualization tool provides building-level energy performance data for the {{ ::yearsString }} calendar years for the nearly 2,000 properties required to report utility information as part of Philadelphia’s energy benchmarking law. You can learn more about energy benchmarking and read the benchmarking reports at <a href="{{ ::info.benchmarking_url }}" target="_blank">{{ ::getPrettyUrl(info.benchmarking_url) }}</a>.</p>
             <br>
 
             <h4>Building Energy Performance</h4>

--- a/app/scripts/views/info/module.js
+++ b/app/scripts/views/info/module.js
@@ -9,7 +9,17 @@
             parent: 'root',
             url: '/info?year',
             templateUrl: 'scripts/views/info/info-partial.html',
-            controller: 'InfoController'
+            controller: 'InfoController',
+            resolve: /* ngInject */ {
+                infoData: ['yearData', '$stateParams', 'CartoSQLAPI',
+                    function (yearData, $stateParams, CartoSQLAPI) {
+
+                    CartoSQLAPI.setYears(yearData);
+                    return CartoSQLAPI.getInfoData().then(function(data) {
+                        return CartoSQLAPI.getInfo(data.data.rows);
+                    });
+                }]
+            }
         });
     }
 


### PR DESCRIPTION
## Overview

Pull text and links for the info page that are likely to change from a Carto table of key/value pairs. In creating the table, added some links that were missing from the last deployed version. Also updated the text for the greenhouse gas emission goal, according to page 19 of the [latest report (pdf)](https://beta.phila.gov/media/20161101174249/2016-Greenworks-Vision_Office-of-Sustainability.pdf).

## Demo
![image](https://user-images.githubusercontent.com/960264/31350780-6b5e93ac-acf6-11e7-908a-03687427aa1e.png)

The table:
![image](https://user-images.githubusercontent.com/960264/31350903-e5990350-acf6-11e7-89bc-9cf3f1205237.png)


## Testing

 - visit [info page](http://localhost:9000/#!/info)
 - links should work
 - no text snippets should be missing

Closes #245.