### PR TITLE
Display Site EUI if Energy Star score is missing

### DIFF
--- a/app/scripts/views/detail/detail-partial.html
+++ b/app/scripts/views/detail/detail-partial.html
@@ -9,9 +9,15 @@
                 <p ng-show="building.year_built"><i>Year Built: {{ ::building.year_built }}</i></p>
             </div>
             <div class="col-xs-4 pull-right">
-                <div class="energy-star center-block text-center">
+                <div class="energy-star center-block text-center"
+                    ng-if="(building['energy_star_' + selectedYear] | cartodbNumber:0) !== 'N/A'">
                     <h4>{{ ::building['energy_star_' + selectedYear] | cartodbNumber:0 }}</h4>
                     <label>Energy Star Score</label>
+                </div>
+                <div class="energy-star center-block text-center"
+                    ng-if="(building['energy_star_' + selectedYear] | cartodbNumber:0) === 'N/A'">
+                    <h4>{{ ::building['site_eui_' + selectedYear] | cartodbNumber:0 }}</h4>
+                    <label>Site EUI</label>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
On property details page, fall back to displaying Site EUI instead of N/A for Energy Star score that is missing.
If both are missing, will display N/A for Site EUI.

Closes #231.

Has Energy Star score:
![image](https://user-images.githubusercontent.com/960264/31351483-4ebe58f6-acf9-11e7-8cdd-eeba7bac4310.png)

Missing Energy Star but have Site EUI:
![image](https://user-images.githubusercontent.com/960264/31351518-6a215238-acf9-11e7-8149-3baa328bb40f.png)

Missing both:
![image](https://user-images.githubusercontent.com/960264/31351467-3ebda542-acf9-11e7-926e-ff96fd25be26.png)
