### PR TITLE
Feature/kak/graph popover#232

### DIFF
--- a/app/scripts/charting/histogram-directive.js
+++ b/app/scripts/charting/histogram-directive.js
@@ -137,12 +137,13 @@
                             var popup = '<span>';
                             for (var i = 0; i < calloutValues.length; i++) {
                                 var val = calloutValues[i];
-                                var style = calloutColors[i] ?
-                                    'color:' + calloutColors[i] + ';' : '';
-                                style += val === d ? 'font-weight=bolder' : '';
-                                popup += ['<p style="',
+                                var style =  calloutColors[i] ?
+                                    'style="color:' + calloutColors[i] + ';"' : '"';
+                                var cls = val === d ? ' class="underline"' : '';
+                                popup += ['<p ',
                                           style,
-                                          '">',
+                                          cls,
+                                          '>',
                                           labels[i],
                                           ': ',
                                           $filter('cartodbNumber')(val, 0),

--- a/app/scripts/views/compare/compare-controller.js
+++ b/app/scripts/views/compare/compare-controller.js
@@ -17,8 +17,8 @@
     /*
      * ngInject
      */
-    function CompareController($scope, BuildingCompare, CartoSQLAPI, CompareConfig, MOSCSSValues,
-                               buildingData, currentData) {
+    function CompareController($location, $scope, BuildingCompare, CartoSQLAPI, CompareConfig,
+                               MOSCSSValues, buildingData, currentData) {
 
         var year = CartoSQLAPI.getCurrentYear();
 
@@ -36,7 +36,9 @@
 
         $scope.year = year;
         $scope.buildings = buildingData.data.rows;
+        /*jshint camelcase: false */
         $scope.buildingNames = _.map($scope.buildings, 'property_name');
+        /*jshint camelcase: true */
         $scope.fields = CompareConfig.fields;
         $scope.currentData = currentData.data.rows;
         $scope.cssValues = MOSCSSValues;
@@ -49,12 +51,23 @@
 
         $scope.close = function (index) {
             /*jshint camelcase: false */
-            var cartodbId = $scope.buildings[index].cartodb_id;
+            var cartodbId = $scope.buildings[index].cartodb_id.toString();
             /*jshint camelcase: true */
-            BuildingCompare.remove(cartodbId.toString());
+            BuildingCompare.remove(cartodbId);
             $scope.buildings.splice(index, 1);
             $scope.buildingNames.splice(index, 1);
             $scope.calloutValues = setCalloutValues($scope.buildings, CompareConfig.fields);
+
+            // update URL to remove building ID
+            var urlIds = $location.search().ids;
+            if (urlIds) {
+                urlIds = urlIds.split(',');
+                var idx = _.indexOf(urlIds, cartodbId);
+                if (idx > -1) {
+                    urlIds.splice(idx, 1);
+                    $location.search('ids', urlIds.join(','));
+                }
+            }
         };
     }
 

--- a/app/scripts/views/compare/compare-controller.js
+++ b/app/scripts/views/compare/compare-controller.js
@@ -36,6 +36,7 @@
 
         $scope.year = year;
         $scope.buildings = buildingData.data.rows;
+        $scope.buildingNames = _.map($scope.buildings, 'property_name');
         $scope.fields = CompareConfig.fields;
         $scope.currentData = currentData.data.rows;
         $scope.cssValues = MOSCSSValues;
@@ -52,6 +53,7 @@
             /*jshint camelcase: true */
             BuildingCompare.remove(cartodbId.toString());
             $scope.buildings.splice(index, 1);
+            $scope.buildingNames.splice(index, 1);
             $scope.calloutValues = setCalloutValues($scope.buildings, CompareConfig.fields);
         };
     }

--- a/app/scripts/views/compare/compare-partial.html
+++ b/app/scripts/views/compare/compare-partial.html
@@ -39,6 +39,7 @@
                                        value-field="'{{key}}'"
                                        callout-values="calloutValues[key]"
                                        callout-colors="calloutColors"
+                                       labels="buildingNames"
                                        allow-redraw="true">
                         </mos-histogram>
                     </td>

--- a/app/scripts/views/detail/detail-controller.js
+++ b/app/scripts/views/detail/detail-controller.js
@@ -41,7 +41,6 @@
         $scope.currentData = rows;
         $scope.cssValues = MOSCSSValues;
         $scope.filterField = 'sector';
-        $scope.calloutColors = [sectorColor];
         $scope.FILTER = DetailConfig.FILTER;
         $scope.dropdownText = {};
         $scope.dropdownText[DetailConfig.FILTER.NONE] = 'All Buildings';
@@ -67,7 +66,14 @@
         // Returns an array of callout values for the given key
         $scope.getCalloutValues = function (key) {
             return _.map($scope.years, function(year) {
-                return building[key + '_' + year] ? building[key + '_' + year] : 'N/A';
+                var vals = building[key + '_' + year] ? building[key + '_' + year] : 'N/A';
+                return vals;
+            });
+        };
+
+        $scope.getCalloutColors = function () {
+            return _.map($scope.years, function(year) {
+                return year === $scope.selectedYear ? sectorColor : '';
             });
         };
     }

--- a/app/scripts/views/detail/detail-partial.html
+++ b/app/scripts/views/detail/detail-partial.html
@@ -76,7 +76,8 @@
         </div>
         <div class="col-xs-5">
             <div class="row">
-                <div class="col-xs-12" ng-init="calloutValues = getCalloutValues(key)">
+                <div class="col-xs-12" ng-init="calloutValues = getCalloutValues(key);
+                    calloutColors = getCalloutColors()">
                     <mos-histogram plot-height="100"
                                    plot-width="400"
                                    data="currentData"

--- a/app/scripts/views/detail/detail-partial.html
+++ b/app/scripts/views/detail/detail-partial.html
@@ -84,6 +84,7 @@
                                    value-field="'{{key}}'"
                                    callout-values="calloutValues"
                                    callout-colors="calloutColors"
+                                   labels="years"
                                    allow-redraw="true">
                     </mos-histogram>
                 </div>

--- a/app/styles/_d3-common.scss
+++ b/app/styles/_d3-common.scss
@@ -5,6 +5,10 @@
   background: rgba(0, 0, 0, 0.8);
   color: #fff;
   border-radius: 2px;
+
+  .underline {
+    text-decoration: underline;
+  }
 }
 
 .d3-tip:after {


### PR DESCRIPTION
## Overview

Adds a popover to the detail and comparison page charts.

Sets the row for the hovered value to a bolder font, though the styling seems to be getting overridden elsewhere.

The issue was to just add the popover to the detail page, but the comparison page uses the same chart directive, so it's getting popovers, too; could instead disable them conditionally on the comparison page if that's better.

### Detail page:
![detail_popover](https://user-images.githubusercontent.com/960264/31640012-e02d18d0-b2a9-11e7-9cb9-e4bfb1eb2589.png)


### Comparison page:
![compare_popover](https://user-images.githubusercontent.com/960264/31640016-e2de6d5e-b2a9-11e7-8552-b27ef1afe3cb.png)



Closes #232.
Fixes #255.