### PR TITLE
Add explicit reference to bower registry

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "bower_components"
+  "directory": "bower_components",
+  "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
See: https://gist.github.com/sheerun/c04d856a7a368bad2896ff0c4958cb00
Old bower registry has been deprecated.
Add explicity bower registry URL reference, in case project built with old bower version.