### PR TITLE
Feature/kak/parameterize visualization#257

### DIFF
--- a/app/scripts/cartodb/cartodb-api-config.js
+++ b/app/scripts/cartodb/cartodb-api-config.js
@@ -8,7 +8,6 @@
         var module = {};
 
         module.user = 'mos-benchmarking';
-        module.visualization = '41298fb7-e6c7-4c49-8131-3383a7ac5fe1';
 
         // The unique column to use to identify records throughout the app
         module.uniqueColumn = 'cartodb_id';

--- a/app/scripts/cartodb/cartodb-api-service.js
+++ b/app/scripts/cartodb/cartodb-api-service.js
@@ -6,19 +6,23 @@
      */
     function CartoSQLAPI ($http, $location, $rootScope, CartoConfig, MOSTablePrefix, Utils) {
         var module = {};
+        var yearsData = {};
 
         // years will be queried from Carto
         // app displays the most recent three years' worth of data
         // download links for all available years are available in the dropdown
         module.years = [];
         module.allYears = [];
-        module.yearsData = {};
         module.getCurrentYear = getCurrentYear;
 
         // There is now only a single table, which contains data for all years.
         // The naming convention for the table is: mos_beb_{underscore seperated ascending years}.
         // The `slice` is here to make the sort non-destructive.
         module.getTableName = getTableName;
+
+        module.yearsData = function() {
+            return yearsData;
+        };
 
         /*
          *  Builds subset of renamed data fields from full query, for charts
@@ -108,15 +112,15 @@
         /**
          * Process the result of the `getYearsData` query and set the data on the service
          */
-        module.setYears = function(yearsData) {
+        module.setYears = function(data) {
 
             var queryiedYears = [];
 
-            angular.forEach(yearsData.data.rows, function(row) {
+            angular.forEach(data.data.rows, function(row) {
                 queryiedYears.push(row.year);
 
                 /* jshint camelcase:false */
-                module.yearsData[row.year] = {
+                yearsData[row.year] = {
                     downloadUrl: row.download_url,
                     avgEnergyStar: row.avg_energy_star,
                     ghgBuildings: row.ghg_buildings,

--- a/app/scripts/views/charts/charts-controller.js
+++ b/app/scripts/views/charts/charts-controller.js
@@ -26,7 +26,7 @@
             // The chart view displays both the data year and the report year (there is a 1-year lag)
             $scope.dataYear = CartoSQLAPI.getCurrentYear();
             $scope.reportYear = $scope.dataYear + 1;
-            $scope.stats = CartoSQLAPI.yearsData[$scope.dataYear];
+            $scope.stats = CartoSQLAPI.yearsData()[$scope.dataYear];
 
             var getCurrentAll = CartoSQLAPI.getAllCurrentData().then(function(data) {
                 $scope.currentAllData = data.data.rows;

--- a/app/scripts/views/map/map-controller.js
+++ b/app/scripts/views/map/map-controller.js
@@ -5,7 +5,7 @@
      * ngInject
      */
     function MapController($compile, $q, $scope, $state, $timeout, BuildingCompare, CartoConfig,
-                           CartoSQLAPI, ColorService, MappingService, Utils) {
+                           CartoSQLAPI, ColorService, MappingService, Utils, infoData) {
 
         // indicate that map is loading, hang on..
         $scope.mapLoading = true;
@@ -295,7 +295,7 @@
         // load map visualization
         var vizUrl = Utils.strFormat('https://{user}.carto.com/api/v2/viz/{viz}/viz.json', {
             user: CartoConfig.user,
-            viz: CartoConfig.visualization
+            viz: infoData.visualization
         });
 
         /* jshint camelcase:false */

--- a/app/scripts/views/map/module.js
+++ b/app/scripts/views/map/module.js
@@ -9,7 +9,17 @@
             parent: 'root',
             url: '/map?year',
             templateUrl: 'scripts/views/map/map-partial.html',
-            controller: 'MapController'
+            controller: 'MapController',
+            resolve: /* ngInject */ {
+                infoData: ['yearData', '$stateParams', 'CartoSQLAPI',
+                    function (yearData, $stateParams, CartoSQLAPI) {
+
+                    CartoSQLAPI.setYears(yearData);
+                    return CartoSQLAPI.getInfoData().then(function(data) {
+                        return CartoSQLAPI.getInfo(data.data.rows);
+                    });
+                }]
+            }
         });
     }
 

--- a/app/scripts/years/data-download-controller.js
+++ b/app/scripts/years/data-download-controller.js
@@ -7,12 +7,12 @@
     function DataDownloadController($scope, CartoSQLAPI) {
         var ctl = this;
         ctl.years = CartoSQLAPI.allYears;
-        ctl.yearsData = CartoSQLAPI.yearsData;
+        ctl.yearsData = CartoSQLAPI.yearsData();
 
         // Update years values and download links after they have been loaded from Carto
         $scope.$on('mos.cartodb:years', function() {
             ctl.years = CartoSQLAPI.allYears;
-            ctl.yearsData = CartoSQLAPI.yearsData;
+            ctl.yearsData = CartoSQLAPI.yearsData();
         });
 
     }

--- a/test/spec/views/charts.js
+++ b/test/spec/views/charts.js
@@ -1,7 +1,6 @@
 describe('Controller: mos.views.charts.ChartsController', function () {
     'use strict';
 
-    beforeEach(module('ui.router'));
     // load the controller's module
     beforeEach(module('mos'));
 
@@ -30,7 +29,6 @@ describe('Controller: mos.views.charts.ChartsController', function () {
     }));
 
     it('should stub a sample test', function () {
-        // TODO: #243 fix transition rejection
         expect(true).toBe(true);
     });
 });

--- a/test/spec/views/map.js
+++ b/test/spec/views/map.js
@@ -6,6 +6,11 @@ describe('Controller: mos.views.map.MapController', function () {
 
     var scope;
     var Controller;
+    var currentData = {
+        data: {
+            rows: []
+        }
+    };
 
     // Initialize the controller and a mock scope
     beforeEach(inject(function ($controller, $rootScope, _$compile_, _$state_) {
@@ -14,6 +19,7 @@ describe('Controller: mos.views.map.MapController', function () {
         Controller = $controller('MapController', {
             $compile: _$compile_,
             $scope: scope,
+            infoData: currentData,
             $state: _$state_
         });
     }));

--- a/test/spec/years/year-selector-directive.spec.js
+++ b/test/spec/years/year-selector-directive.spec.js
@@ -41,6 +41,8 @@ describe('Directive: mos.years.YearSelector', function () {
 
         $httpBackend.expectGET(/*mos_beb*/).respond(200, {});
 
+        $httpBackend.expectGET(/*charts/charts-partial.html*/).respond(200, '<h1>hi</h1>');
+
         $rootScope.$apply();
 
         $httpBackend.flush();


### PR DESCRIPTION
To support using a different visualization on staging than in production, get the visualization Carto ID from the `info` table. In all other respects, the staging and production data from Carto are separate; see #246.

Also fixes a test that was passing but would produce a 'transition rejection' error at the console, and refactors access to the years list into a function.

Closes #257.
Fixes #243.