### PR TITLE
Add row for Energy Star to details

### DIFF
--- a/app/scripts/views/detail/detail-controller.js
+++ b/app/scripts/views/detail/detail-controller.js
@@ -6,6 +6,7 @@
      */
     var DetailConfig = {
         fields: [
+            'energy_star',
             'site_eui',
             'total_ghg',
             'electricity',


### PR DESCRIPTION
In addition to displaying the Energy Star score for the current year in the header,
add a row to the building details page for the Energy Star readings for all three years.

Closes #262.

![image](https://user-images.githubusercontent.com/960264/32175368-203a3c76-bd5b-11e7-8c6f-e84c19f0b67a.png)
