### PR TITLE
Style unknown sectors as Other

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -26,8 +26,7 @@
         'Parking': '#62afe8',
         'Laboratory': '#3AA3FF',
         'Hospital': '#C6B4FF',
-        'Data Center': '#a3d895',
-        'Unknown': '#DDDDDD'
+        'Data Center': '#a3d895'
     };
 
     // min. values and corresponding CSS values for each bucket

--- a/app/scripts/charting/bubblechart-directive.js
+++ b/app/scripts/charting/bubblechart-directive.js
@@ -108,7 +108,7 @@
                     // Radius of zero initially so it can be animated on load
                     .attr('r', 0)
                     .attr('class', 'bubble')
-                    .style('fill', function (d) { return MOSColors[d.name] || MOSColors.Unknown; });
+                    .style('fill', function (d) { return MOSColors[d.name] || MOSColors.Other; });
 
                 nodeEnter.append('text')
                     .attr('dy', '.35em')

--- a/app/scripts/colors/color-service.js
+++ b/app/scripts/colors/color-service.js
@@ -59,8 +59,8 @@
                     if (value in MOSColors) {
                         return MOSColors[value];
                     } else {
-                        // if color not found, use 'Unknown' color
-                        return MOSColors.Unknown;
+                        // if color not found, use 'Other' color
+                        return MOSColors.Other;
                     }
                 } else {
                     console.error('Have no CSS defined for field: ' + field);
@@ -170,8 +170,8 @@
             if (sector in MOSColors) {
                 return MOSColors[sector];
             } else {
-                // if color not found, use 'Unknown' color
-                return MOSColors.Unknown;
+                // if color not found, use 'Other' color
+                return MOSColors.Other;
             }
         };
 
@@ -217,11 +217,7 @@
             var css = '';
             var TABLE = '#' + CartoSQLAPI.getTableName();
             angular.forEach(MOSColors, function(value, key) {
-                if (key === 'Unknown') {
-                    css += '\n' + TABLE + ' {marker-fill: ' + value + ';}';
-                } else {
-                    css += TABLE + '[sector="' + key + '"] {marker-fill: ' + value + ';} ';
-                }
+                css += TABLE + '[sector="' + key + '"] {marker-fill: ' + value + ';} ';
             });
             return css;
         };

--- a/app/scripts/views/detail/detail-controller.js
+++ b/app/scripts/views/detail/detail-controller.js
@@ -30,7 +30,7 @@
         var building = buildingData.data && buildingData.data.rows && buildingData.data.rows.length > 0
                         ? buildingData.data.rows[0] : {};
 /* jshint laxbreak:false */
-        var sectorColor = MOSColors[building.sector] || MOSColors.Unknown;
+        var sectorColor = MOSColors[building.sector] || MOSColors.Other;
         var rows = currentData.data.rows;
 
         $scope.years = CartoSQLAPI.years;


### PR DESCRIPTION
Remove Unknown category from legend and default to Other category for
missing or unrecognized sector labels.

![image](https://user-images.githubusercontent.com/960264/32175740-303f4a16-bd5c-11e7-8e5a-e867b4d4eeda.png)

Closes #264.