### PR TITLE
Feature/kak/fix header reset#267

### DIFF
--- a/app/scripts/headroom-reset-directive.js
+++ b/app/scripts/headroom-reset-directive.js
@@ -2,13 +2,13 @@
     'use strict';
 
     /* ngInject */
-    function HeadroomReset() {
+    function HeadroomReset($transitions) {
         var module = {};
 
         module.restrict = 'A';
 
         module.link = function ($scope, element) {
-            $scope.$on('$stateChangeStart', function () {
+            $transitions.onStart({}, function() {
                 element.addClass('headroom headroom--top');
                 element.removeClass('headroom--not-top headroom--unpinned headroom--pinned');
             });

--- a/app/scripts/views/map/map-controller.js
+++ b/app/scripts/views/map/map-controller.js
@@ -4,8 +4,9 @@
     /*
      * ngInject
      */
-    function MapController($compile, $q, $scope, $state, $timeout, BuildingCompare, CartoConfig,
-                           CartoSQLAPI, ColorService, MappingService, Utils, infoData) {
+    function MapController($compile, $q, $scope, $state, $timeout, $transitions, BuildingCompare,
+                           CartoConfig, CartoSQLAPI, ColorService, MappingService, Utils,
+                           infoData) {
 
         // indicate that map is loading, hang on..
         $scope.mapLoading = true;
@@ -286,7 +287,7 @@
             $('#mymap').append(ColorService.getLegend($scope.selections.colorType));
         };
 
-        $scope.$on('$stateChangeStart', function () {
+        $transitions.onStart({}, function() {
             $timeout(function () {
                 $scope.loadingView = true;
             }, overlayTriggerMillis);

--- a/bower.json
+++ b/bower.json
@@ -4,27 +4,27 @@
   "license": "MIT",
   "dependencies": {
     "panelsnap": "0.15.1",
-    "angular": "~1.6.4",
-    "json3": "~3.3.0",
+    "angular": "~1.6.6",
+    "json3": "~3.3.2",
     "es5-shim": "~4.5.9",
     "bootstrap-sass-official": "~3.3.7",
     "angular-bootstrap": "~2.5.0",
-    "angular-animate": "~1.6.4",
-    "angular-cookies": "~1.6.4",
-    "angular-messages": "~1.6.4",
+    "angular-animate": "~1.6.6",
+    "angular-cookies": "~1.6.6",
+    "angular-messages": "~1.6.6",
     "d3": "~3.5.17",
     "d3-tip": "~0.6.7",
     "lodash": "~4.17.4",
-    "angular-sanitize": "~1.6.4",
-    "angular-ui-router": "~1.0.4"
+    "angular-sanitize": "~1.6.6",
+    "angular-ui-router": "~1.0.10"
   },
   "devDependencies": {
-    "angular-mocks": "~1.6.4",
-    "angular-scenario": "~1.6.4",
+    "angular-mocks": "~1.6.6",
+    "angular-scenario": "~1.6.6",
     "karma-read-json": "^1.1.0"
   },
   "appPath": "app",
   "resolutions": {
-    "angular": "~1.6.4"
+    "angular": "~1.6.6"
   }
 }


### PR DESCRIPTION
Fixes header not resetting on tab switch.
`ui-router` usage changed with version 1.x:
https://ui-router.github.io/guide/ng1/migrate-to-1_0

`$stateChangeStart` and `$stateChangeSuccess` were replaced with `$transition` events.
Updates events in the app. Also makes some minor package upgrades (not required for the header fix).

Fixes #267.