### PR TITLE
Update page title

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html class="no-js">
   <head>
     <meta charset="utf-8">
-    <title>MOS - Energy Benchmarking</title>
+    <title>Philadelphia Energy Benchmarking</title>
     <link rel="icon" type="image/xicon" href="images/favicon.ico">
     <meta name="description" content="">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Lato:300,400,400italic|Roboto+Slab:700">


### PR DESCRIPTION
Page title still referenced MOS, now OOS.
Change to just "Philadelphia", per client.

Closes #274.