### PR TITLE
Fix address/building ID search

### DIFF
--- a/app/scripts/views/map/map-partial.html
+++ b/app/scripts/views/map/map-partial.html
@@ -18,6 +18,7 @@
                     typeahead-loading="loadingSuggestions"
                     typeahead-wait-ms="400"
                     typeahead-min-length="3"
+                    typeahead-on-select="searchMap()"
                     ng-submit="searchMap()"
                     ng-change="clearErrorMsg()"
                     ng-keyup="$event.keyCode === 13 ? searchMap() : null"


### PR DESCRIPTION
On address select, event would not fire to zoom to geocoded location.
Possibly due to changes in the angular bootstrap library in use:
https://angular-ui.github.io/bootstrap/

Fixes #277.

On searching an address:
![image](https://user-images.githubusercontent.com/960264/32347140-178b3f20-bfe6-11e7-942c-18e681387f70.png)

On selection of a building ID:
![image](https://user-images.githubusercontent.com/960264/32347187-3a420d82-bfe6-11e7-9941-2f9446a00357.png)

