### PR TITLE
Make Docker development setup more complete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:xenial
+ARG s3_website_version=2.7.6
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1655A0AB68576280
 
@@ -9,19 +10,20 @@ RUN set -ex \
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 
+# s3_website is actually written in Scala even though it's on Ruby Gems
 RUN set -ex \
     && apt-get update \
-      && apt-get install -y nodejs
+      && apt-get install -y nodejs openjdk-8-jre
 
-RUN gem install sass compass s3_website
+RUN gem install sass compass s3_website:$s3_website_version
+WORKDIR /var/lib/gems/2.3.0/gems/s3_website-$s3_website_version/
+# s3_website downloads and installs its .jar file on first execution
+RUN curl -o s3_website-$s3_website_version.jar -L https://github.com/laurilehmijoki/s3_website/releases/download/v$s3_website_version/s3_website.jar 
 
 WORKDIR /usr/src/app
 
 RUN npm install -g grunt-cli bower
 
 COPY . .
-
-RUN npm install
-RUN bower --allow-root install
 
 EXPOSE 9000

--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ http://visualization.phillybuildingbenchmarking.com/#/
 ### Developing
 
 #### Dependencies
-Docker
+Docker and Docker Compose. The current development setup is known to work with the following versions:
+Docker: 19 and 20
+Docker Compose: 1.23 and 1.27
+
+Other versions are likely to work as well.
 
 #### Setup
 This project is containerized via Docker.
 
-Run `docker build .` from directory root
+Run `./scripts/setup` from directory root
 
 #### Run
-Then run `docker run --rm -p 9000:9000 <image_id> grunt serve`
+Then run `./scripts/server`
 
 The dev app will be served at http://localhost:9000 and automatically opened in a new tab in your default browser.
 
@@ -25,10 +29,8 @@ The app will auto refresh after saving js/css/html
 
 ### Deploying
 
-1. `grunt build --env=prod`
-2. `gem install s3_website` if you haven't already
-3. `export MOS_S3_ID=ENTER_S3_ID_HERE MOS_S3_SECRET=ENTER_S3_SECRET_HERE`
-4. `s3_website push`
+1. `docker-compose run app grunt build --env=prod`
+4. `docker-compose run -e MOS_S3_ID=<AWS_ACCESS_KEY_ID> -e MOS_S3_SECRET=<AWS_SECRET_ACCESS_KEY> app s3_website push`
 
 
 ### Testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.7"
+services:
+  app:
+    build: .
+    command: grunt serve
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "9000:9000"

--- a/scripts/server
+++ b/scripts/server
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${MOS_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Start application.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        docker-compose up
+    fi
+fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${MOS_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Attempts to setup the project's development environment.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        docker-compose build
+        # The following two steps should more correctly be in a ./scripts/update,
+        # but were put here to save time. If we do sustained development on this
+        # project they should be moved. https://github.com/azavea/mos-energy-benchmark/issues/284
+        docker-compose run app npm install
+        docker-compose run app bower --allow-root install
+    fi
+fi


### PR DESCRIPTION
## Overview
Working through the deployment exposed a few areas where our conversion to Docker for development was incomplete, which this resolves (see below for details).

## Notes

- It turns out that `s3_website` is actually a Scala package masquerading as a Ruby Gem, for some reason, so `gem install s3_website` wasn't enough to get it fully installed; it downloads a `.jar` file when it is run for the first time, and also expects to have a Java runtime installed. This does both things in the Dockerfile so they're ready to go when `s3_website` is used.
- This is my fault for forgetting to test this on the previous PR, but it doesn't seem like file sharing was working between the container and the host, so updating the source files wasn't triggering changes in the container without a rebuild. I added docker-compose in order to make volume sharing easier, and file sharing should work now.
- Once I had docker-compose in place it was pretty easy to add a basic STRTA setup and I was already copying from Treetective, which has it, so I did that. This just includes `setup` and `server`, not `update`.

## Testing instructions
- Use `./scripts/setup` and `./scripts/server` and make sure they work.
- With `./scripts/server` running, make sure that editing a file triggers a rebuild.
- Run `docker-compose run -e MOS_S3_ID=whatever -e MOS_S3_SECRET=secret app s3_website push --dry-run` and confirm that it doesn't try to download any `.jar` files and runs "successfully" (it's not going to actually work because the AWS credentials are fake, but it'll attempt to use them to authenticate and then report an error). If you want to try it with real credentials that should work, too, but this has already been used to deploy the production site, so detailed testing isn't necessary.